### PR TITLE
TU-2180: Excluding specific packages from major PR. They will instead…

### DIFF
--- a/renovate-config-no-major.json
+++ b/renovate-config-no-major.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate configuration for dsb-norge projects where major updates are skipped",
+  "enabledManagers": ["npm"],
+  "extends": [
+    ":dependencyDashboard",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":ignoreModulesAndTests",
+    ":autodetectPinVersions",
+    ":prConcurrentLimit10",
+    "workarounds:all",
+    ":pinAllExceptPeerDependencies"
+  ],
+  "packageRules": [
+    {
+      "groupName": "frontend - minor and patch",
+      "matchUpdateTypes": ["minor", "patch"]
+    }
+  ],
+  "major": {
+    "enabled": false
+  },
+  "ignoreScripts": true,
+  "prHourlyLimit": 4,
+  "reviewers": ["dsb-developers"],
+  "schedule": ["after 12:30am and before 3:30am every weekday"],
+  "timezone": "UTC"
+}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate configuration for dsb-norge projects where major updates get separate PRs so that they can be closed (non-immortal)",
   "enabledManagers": ["npm"],
   "extends": [
     ":dependencyDashboard",
@@ -11,18 +13,15 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch"
-      ],
-      "groupName": "frontend"
+      "groupName": "frontend - minor and patch",
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
   "major": {
     "packageRules": [
       {
+        "groupName": "frontend",
+        "matchUpdateTypes": ["major"],
         "excludePackageNames": [
           "@vitejs/plugin-vue",
           "@dsb-norge/eslint-config-dsb-vue",
@@ -38,8 +37,7 @@
         "excludePackagePrefixes": [
           "@vue/cli-",
           "eslint-plugin-"
-        ],
-        "groupName": "frontend (major)"
+        ]
       }
     ]
   },


### PR DESCRIPTION
… get their own PR which can be closed and will then not be recreated (i.e. non-immortal, while the general major PR is immortal). Adding a config where major updates are skipped altogether; if this is preferable then it is easy to switch.