### PR TITLE
renovate iac config update:

### DIFF
--- a/renovate-config-iac.json
+++ b/renovate-config-iac.json
@@ -25,14 +25,9 @@
     "major": {
         "enabled": true
     },
-    "reviewers": [
-        "Artlvns",
-        "Laffs2k5"
-    ],
     "timezone": "UTC",
     "schedule": [
-        "after 03:30am and before 7:30am every weekday",
-        "every weekend"
+        "after 03:30am and before 7:30am"
     ],
     "updateNotScheduled": true,
     "labels": [


### PR DESCRIPTION
chore: remove reviewers to avoid email noise until further.
chore: change schedulle to run every night at the same time ( aligned with TF runners as well).