### PR TITLE
Consumes GitHub Dependabot alerts to bump vulnerable transitive depen…

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -82,6 +82,11 @@
       "allowedVersions": "<1.14.1 || >1.14.1"
     }
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "automerge": false,
+    "labels": ["security", "pr-created-by-renovate"]
+  },
   "minimumReleaseAge": "7 days",
   "ignoreScripts": true,
   "prHourlyLimit": 4,

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -84,7 +84,8 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": true,
-    "automerge": false,
+    "automerge": true,
+    "minimumReleaseAge": "7 days",
     "labels": ["security", "pr-created-by-renovate"]
   },
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
…dencies in the lockfile within the parent's allowed semver range. Keeps automerge off for security PRs so a human reviews each one, since vulnerability alerts bypass the 7-day minimumReleaseAge window.